### PR TITLE
:arrow_up: Update rust edition 2018 to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ Rust bindings to liblzma providing Read/Write streams as well as low-level
 in-memory encoding/decoding.
 """
 categories = ["compression", "api-bindings"]
-edition = "2018"
+edition = "2021"
 
 [workspace]
 members = ["systest"]

--- a/liblzma-sys/Cargo.toml
+++ b/liblzma-sys/Cargo.toml
@@ -15,7 +15,7 @@ encoding/decoding.
 High level Rust bindings are available in the `liblzma` crate.
 """
 categories = ["external-ffi-bindings"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libc = "0.2.51"

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -3,7 +3,7 @@ name = "systest"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 liblzma-sys = { path = "../liblzma-sys" }


### PR DESCRIPTION
Update Rust edition to 2021.
This change requires a minimum version of Rust 1.56.0 or higher.