### PR TITLE
Enhance wasm-shim

### DIFF
--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -35,3 +35,23 @@ jobs:
       - name: Run build
         run: |
           cargo build --target ${{ matrix.target }} --features wasm
+
+  test_without_wasi_sdk:
+    name: Test WebAssembly
+    strategy:
+      matrix:
+        target:
+          - wasm32-unknown-unknown
+          - wasm32-wasi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: ${{ matrix.target }}
+          toolchain: stable
+      - name: Run build
+        run: |
+          cargo build --target ${{ matrix.target }} --features wasm

--- a/liblzma-sys/src/wasm_shim.rs
+++ b/liblzma-sys/src/wasm_shim.rs
@@ -1,6 +1,5 @@
+use core::ffi::{c_char, c_int, c_void};
 use std::alloc::{alloc, dealloc, Layout};
-use std::ffi::c_int;
-use std::os::raw::c_void;
 
 #[no_mangle]
 pub extern "C" fn rust_lzma_wasm_shim_malloc(size: usize) -> *mut c_void {
@@ -30,8 +29,8 @@ pub unsafe extern "C" fn rust_lzma_wasm_shim_free(ptr: *mut c_void) {
 
 #[no_mangle]
 pub extern "C" fn rust_lzma_wasm_shim_memcmp(
-    str1: *const std::ffi::c_void,
-    str2: *const std::ffi::c_void,
+    str1: *const c_void,
+    str2: *const c_void,
     n: usize,
 ) -> i32 {
     // Safety: function contracts requires str1 and str2 at least `n`-long.
@@ -48,46 +47,46 @@ pub extern "C" fn rust_lzma_wasm_shim_memcmp(
 
 #[no_mangle]
 pub unsafe extern "C" fn rust_lzma_wasm_shim_memcpy(
-    dest: *mut std::ffi::c_void,
-    src: *const std::ffi::c_void,
+    dest: *mut c_void,
+    src: *const c_void,
     n: usize,
-) -> *mut std::ffi::c_void {
+) -> *mut c_void {
     core::ptr::copy_nonoverlapping(src as *const u8, dest as *mut u8, n);
     dest
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn rust_lzma_wasm_shim_memmove(
-    dest: *mut std::ffi::c_void,
-    src: *const std::ffi::c_void,
+    dest: *mut c_void,
+    src: *const c_void,
     n: usize,
-) -> *mut std::ffi::c_void {
+) -> *mut c_void {
     core::ptr::copy(src as *const u8, dest as *mut u8, n);
     dest
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn rust_lzma_wasm_shim_memset(
-    dest: *mut std::ffi::c_void,
+    dest: *mut c_void,
     c: c_int,
     n: usize,
-) -> *mut std::ffi::c_void {
+) -> *mut c_void {
     core::ptr::write_bytes(dest as *mut u8, c as u8, n);
     dest
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rust_lzma_wasm_shim_strlen(s: *mut std::ffi::c_char) -> usize {
+pub unsafe extern "C" fn rust_lzma_wasm_shim_strlen(s: *const c_char) -> usize {
     let str = unsafe { std::ffi::CStr::from_ptr(s) };
     str.to_bytes().len()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn rust_lzma_wasm_shim_memchr(
-    s: *mut std::ffi::c_void,
-    c: std::ffi::c_int,
+    s: *const c_void,
+    c: c_int,
     n: usize,
-) -> *mut std::ffi::c_void {
+) -> *mut c_void {
     let s_slice = unsafe { core::slice::from_raw_parts(s as *const u8, n) };
     s_slice
         .iter()

--- a/liblzma-sys/src/wasm_shim.rs
+++ b/liblzma-sys/src/wasm_shim.rs
@@ -1,4 +1,5 @@
 use std::alloc::{alloc, dealloc, Layout};
+use std::ffi::c_int;
 use std::os::raw::c_void;
 
 #[no_mangle]
@@ -25,4 +26,73 @@ pub unsafe extern "C" fn rust_lzma_wasm_shim_free(ptr: *mut c_void) {
     // layout is not actually used
     let layout = Layout::from_size_align_unchecked(1, 1);
     dealloc(ptr.cast(), layout);
+}
+
+#[no_mangle]
+pub extern "C" fn rust_lzma_wasm_shim_memcmp(
+    str1: *const std::ffi::c_void,
+    str2: *const std::ffi::c_void,
+    n: usize,
+) -> i32 {
+    // Safety: function contracts requires str1 and str2 at least `n`-long.
+    unsafe {
+        let str1: &[u8] = core::slice::from_raw_parts(str1 as *const u8, n);
+        let str2: &[u8] = core::slice::from_raw_parts(str2 as *const u8, n);
+        match str1.cmp(str2) {
+            core::cmp::Ordering::Less => -1,
+            core::cmp::Ordering::Equal => 0,
+            core::cmp::Ordering::Greater => 1,
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_lzma_wasm_shim_memcpy(
+    dest: *mut std::ffi::c_void,
+    src: *const std::ffi::c_void,
+    n: usize,
+) -> *mut std::ffi::c_void {
+    core::ptr::copy_nonoverlapping(src as *const u8, dest as *mut u8, n);
+    dest
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_lzma_wasm_shim_memmove(
+    dest: *mut std::ffi::c_void,
+    src: *const std::ffi::c_void,
+    n: usize,
+) -> *mut std::ffi::c_void {
+    core::ptr::copy(src as *const u8, dest as *mut u8, n);
+    dest
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_lzma_wasm_shim_memset(
+    dest: *mut std::ffi::c_void,
+    c: c_int,
+    n: usize,
+) -> *mut std::ffi::c_void {
+    core::ptr::write_bytes(dest as *mut u8, c as u8, n);
+    dest
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_lzma_wasm_shim_strlen(s: *mut std::ffi::c_char) -> usize {
+    let str = unsafe { std::ffi::CStr::from_ptr(s) };
+    str.to_bytes().len()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_lzma_wasm_shim_memchr(
+    s: *mut std::ffi::c_void,
+    c: std::ffi::c_int,
+    n: usize,
+) -> *mut std::ffi::c_void {
+    let s_slice = unsafe { core::slice::from_raw_parts(s as *const u8, n) };
+    s_slice
+        .iter()
+        .position(|&r| r == c as u8)
+        .map_or(core::ptr::null_mut(), |p| unsafe {
+            s.add(p) as *mut c_void
+        })
 }

--- a/liblzma-sys/wasm-shim/assert.h
+++ b/liblzma-sys/wasm-shim/assert.h
@@ -1,0 +1,6 @@
+#ifndef _ASSERT_H
+#define _ASSERT_H
+
+#define assert(expr)
+
+#endif // _ASSERT_H

--- a/liblzma-sys/wasm-shim/string.h
+++ b/liblzma-sys/wasm-shim/string.h
@@ -1,0 +1,37 @@
+#include <stdlib.h>
+
+#ifndef	_STRING_H
+#define	_STRING_H	1
+
+int rust_lzma_wasm_shim_memcmp(const void *str1, const void *str2, size_t n);
+void *rust_lzma_wasm_shim_memcpy(void *restrict dest, const void *restrict src, size_t n);
+void *rust_lzma_wasm_shim_memmove(void *dest, const void *src, size_t n);
+void *rust_lzma_wasm_shim_memset(void *dest, int c, size_t n);
+size_t rust_lzma_wasm_shim_strlen(const char *s);
+void *rust_lzma_wasm_shim_memchr(const void *s, int c, size_t n);
+
+inline int memcmp(const void *str1, const void *str2, size_t n) {
+    return rust_lzma_wasm_shim_memcmp(str1, str2, n);
+}
+
+inline void *memcpy(void *restrict dest, const void *restrict src, size_t n) {
+	return rust_lzma_wasm_shim_memcpy(dest, src, n);
+}
+
+inline void *memmove(void *dest, const void *src, size_t n) {
+	return rust_lzma_wasm_shim_memmove(dest, src, n);
+}
+
+inline void *memset(void *dest, int c, size_t n) {
+	return rust_lzma_wasm_shim_memset(dest, c, n);
+}
+
+inline void *memchr(const void *s, int c, size_t n) {
+    return rust_lzma_wasm_shim_memchr(s, c, n);
+}
+
+inline size_t strlen(const char *s) {
+    return rust_lzma_wasm_shim_strlen(s);
+}
+
+#endif // _STRING_H


### PR DESCRIPTION
Improved ease of compiling to WebAssembly targets (wasm32-wasi, wasm32-unknown-unknown). enhancements to wasm-shim to enable compiling against WebAssembly targets without wasi-sdk.

close #80 