### PR TITLE
Add AutoFinish[En/De]coder

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -1,5 +1,7 @@
 //! Writer-based compression/decompression streams
 
+mod auto_finish;
+
 use std::io;
 use std::io::prelude::*;
 
@@ -11,6 +13,7 @@ use tokio_io::{try_nb, AsyncRead, AsyncWrite};
 #[cfg(feature = "parallel")]
 use crate::stream::MtStreamBuilder;
 use crate::stream::{Action, Check, Status, Stream};
+pub use auto_finish::{AutoFinishXzDecoder, AutoFinishXzEncoder};
 
 /// A compression stream which will have uncompressed data written to it and
 /// will write compressed data to an output stream.

--- a/src/write.rs
+++ b/src/write.rs
@@ -17,6 +17,8 @@ pub use auto_finish::{AutoFinishXzDecoder, AutoFinishXzEncoder};
 
 /// A compression stream which will have uncompressed data written to it and
 /// will write compressed data to an output stream.
+/// [XzEncoder] will no longer perform the finalization automatically in the next miner release, so you need to call [XzEncoder::finish] manually.
+/// If you want to automate the finalization process, please use [XzEncoder::auto_finish].
 pub struct XzEncoder<W: Write> {
     data: Stream,
     obj: Option<W>,
@@ -25,6 +27,8 @@ pub struct XzEncoder<W: Write> {
 
 /// A compression stream which will have compressed data written to it and
 /// will write uncompressed data to an output stream.
+/// [XzDecoder] will no longer perform the finalization automatically in the next miner release, so you need to call [XzDecoder::finish] manually.
+/// If you want to automate the finalization process, please use [XzDecoder::auto_finish].
 pub struct XzDecoder<W: Write> {
     data: Stream,
     obj: Option<W>,
@@ -139,6 +143,13 @@ impl<W: Write> XzEncoder<W> {
     #[inline]
     pub fn total_in(&self) -> u64 {
         self.data.total_in()
+    }
+
+    /// Convert to [AutoFinishXzEncoder] that impl [Drop] trait.
+    /// [AutoFinishXzEncoder] automatically calls [XzDecoder::try_finish] method when exiting the scope.
+    #[inline]
+    pub fn auto_finish(self) -> AutoFinishXzEncoder<W> {
+        AutoFinishXzEncoder(self)
     }
 }
 
@@ -322,6 +333,13 @@ impl<W: Write> XzDecoder<W> {
     #[inline]
     pub fn total_in(&self) -> u64 {
         self.data.total_in()
+    }
+
+    /// Convert to [AutoFinishXzDecoder] that impl [Drop] trait.
+    /// [AutoFinishXzDecoder] automatically calls [XzDecoder::try_finish] method when exiting the scope.
+    #[inline]
+    pub fn auto_finish(self) -> AutoFinishXzDecoder<W> {
+        AutoFinishXzDecoder(self)
     }
 }
 

--- a/src/write/auto_finish.rs
+++ b/src/write/auto_finish.rs
@@ -1,0 +1,183 @@
+use crate::write::{XzDecoder, XzEncoder};
+use std::io;
+use std::io::Write;
+
+/// A compression stream which will have uncompressed data written to it and
+/// will write compressed data to an output stream.
+/// [AutoFinishXzEncoder] impl [Drop] trait, so automatically calls [XzEncoder::try_finish] method when exiting the scope.
+/// However, it is not guaranteed that `try_finish` will complete successfully, and it is recommended to call `try_finish` manually if you want to ensure that the process is successful.
+pub struct AutoFinishXzEncoder<W: Write>(pub(super) XzEncoder<W>);
+
+impl<W: Write> AutoFinishXzEncoder<W> {
+    /// Acquires a reference to the underlying writer.
+    #[inline]
+    pub fn get_ref(&self) -> &W {
+        self.0.get_ref()
+    }
+
+    /// Acquires a mutable reference to the underlying writer.
+    ///
+    /// Note that mutating the output/input state of the stream may corrupt this
+    /// object, so care must be taken when using this method.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut W {
+        self.0.get_mut()
+    }
+
+    /// Attempt to finish this output stream, writing out final chunks of data.
+    ///
+    /// Note that this function can only be used once data has finished being
+    /// written to the output stream. After this function is called then further
+    /// calls to `write` may result in a panic.
+    ///
+    /// # Panics
+    ///
+    /// Attempts to write data to this stream may result in a panic after this
+    /// function is called.
+    #[inline]
+    pub fn try_finish(&mut self) -> io::Result<()> {
+        self.0.try_finish()
+    }
+
+    /// Consumes this encoder, flushing the output stream.
+    ///
+    /// This will flush the underlying data stream and then return the contained
+    /// writer if the flush succeeded.
+    ///
+    /// Note that this function may not be suitable to call in a situation where
+    /// the underlying stream is an asynchronous I/O stream. To finish a stream
+    /// the `try_finish` method should be used instead. To
+    /// re-acquire ownership of a stream it is safe to call this method after
+    /// `try_finish` has returned `Ok`.
+    #[inline]
+    pub fn finish(mut self) -> io::Result<W> {
+        self.try_finish()?;
+        Ok(self.0.obj.take().unwrap())
+    }
+
+    /// Returns the number of bytes produced by the compressor
+    ///
+    /// Note that, due to buffering, this only bears any relation to
+    /// `total_in()` after a call to `flush()`.  At that point,
+    /// `total_out() / total_in()` is the compression ratio.
+    #[inline]
+    pub fn total_out(&self) -> u64 {
+        self.0.total_out()
+    }
+
+    /// Returns the number of bytes consumed by the compressor
+    /// (e.g. the number of bytes written to this stream.)
+    #[inline]
+    pub fn total_in(&self) -> u64 {
+        self.0.total_out()
+    }
+}
+
+impl<W: Write> Write for AutoFinishXzEncoder<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<W: Write> Drop for AutoFinishXzEncoder<W> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.0.obj.is_some() {
+            let _ = self.0.try_finish();
+        }
+    }
+}
+
+/// A compression stream which will have compressed data written to it and
+/// will write uncompressed data to an output stream.
+/// [AutoFinishXzDecoder] impl [Drop] trait, so automatically calls [XzDecoder::try_finish] method when exiting the scope.
+/// However, it is not guaranteed that `try_finish` will complete successfully, and it is recommended to call `try_finish` manually if you want to ensure that the process is successful.
+pub struct AutoFinishXzDecoder<W: Write>(pub(super) XzDecoder<W>);
+
+impl<W: Write> AutoFinishXzDecoder<W> {
+    /// Acquires a reference to the underlying writer.
+    #[inline]
+    pub fn get_ref(&self) -> &W {
+        self.0.get_ref()
+    }
+
+    /// Acquires a mutable reference to the underlying writer.
+    ///
+    /// Note that mutating the output/input state of the stream may corrupt this
+    /// object, so care must be taken when using this method.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut W {
+        self.0.get_mut()
+    }
+
+    /// Attempt to finish this output stream, writing out final chunks of data.
+    ///
+    /// Note that this function can only be used once data has finished being
+    /// written to the output stream. After this function is called then further
+    /// calls to `write` may result in a panic.
+    ///
+    /// # Panics
+    ///
+    /// Attempts to write data to this stream may result in a panic after this
+    /// function is called.
+    #[inline]
+    pub fn try_finish(&mut self) -> io::Result<()> {
+        self.0.try_finish()
+    }
+
+    /// Consumes this decoder, flushing the output stream.
+    ///
+    /// This will flush the underlying data stream and then return the contained
+    /// writer if the flush succeeded.
+    ///
+    /// Note that this function may not be suitable to call in a situation where
+    /// the underlying stream is an asynchronous I/O stream. To finish a stream
+    /// the `try_finish` method should be used instead. To
+    /// re-acquire ownership of a stream it is safe to call this method after
+    /// `try_finish` has returned `Ok`.
+    #[inline]
+    pub fn finish(mut self) -> io::Result<W> {
+        self.try_finish()?;
+        Ok(self.0.obj.take().unwrap())
+    }
+
+    /// Returns the number of bytes produced by the decompressor
+    ///
+    /// Note that, due to buffering, this only bears any relation to
+    /// `total_in()` after a call to `flush()`.  At that point,
+    /// `total_in() / total_out()` is the compression ratio.
+    #[inline]
+    pub fn total_out(&self) -> u64 {
+        self.0.total_out()
+    }
+
+    /// Returns the number of bytes consumed by the decompressor
+    /// (e.g. the number of bytes written to this stream.)
+    #[inline]
+    pub fn total_in(&self) -> u64 {
+        self.0.total_in()
+    }
+}
+
+impl<W: Write> Write for AutoFinishXzDecoder<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<W: Write> Drop for AutoFinishXzDecoder<W> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.0.obj.is_some() {
+            let _ = self.0.try_finish();
+        }
+    }
+}


### PR DESCRIPTION
Inspired by zstd add `AutoFinish[En/De]coder`.

`write::Xz[En|De]coder` will no longer perform the finalization automatically in the next miner release, so you need to call `write::Xz[En|De]coder::finish` manually.
If you want to automate the finalization process, please use `write::Xz[En|De]coder::auto_finish`.