### PR TITLE
Wasm32 wasip1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,4 @@
 [target."wasm32-wasi"]
 runner = "wasmtime"
+[target."wasm32-wasip1"]
+runner = "wasmtime"

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -14,12 +14,15 @@ jobs:
           - wasm32-unknown-emscripten
           - wasm32-unknown-unknown
           - wasm32-wasi
+          - wasm32-wasip1
         include:
           - target: wasm32-unknown-emscripten
             container: emscripten/emsdk:latest
           - target: wasm32-unknown-unknown
             container: ghcr.io/portable-network-archive/wasi-sdk-gh-actions:wasi-sdk-20
           - target: wasm32-wasi
+            container: ghcr.io/portable-network-archive/wasi-sdk-gh-actions:wasi-sdk-20
+          - target: wasm32-wasip1
             container: ghcr.io/portable-network-archive/wasi-sdk-gh-actions:wasi-sdk-20
 
     runs-on: ubuntu-latest
@@ -32,16 +35,16 @@ jobs:
         with:
           target: ${{ matrix.target }}
           toolchain: ${{ matrix.rust }}
-      - if: "${{ matrix.target == 'wasm32-wasi' }}"
+      - if: ${{ startsWith(matrix.target, 'wasm32-wasi') }}
         name: Setup wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
           github_token: ${{ github.token }}
-      - if: "${{ matrix.target == 'wasm32-wasi' }}"
+      - if: ${{ startsWith(matrix.target, 'wasm32-wasi') }}
         name: Run test
         run: |
           cargo test --target ${{ matrix.target }} --features wasm -- --skip standard_files
-      - if: "${{ matrix.target != 'wasm32-wasi' }}"
+      - if: ${{ !startsWith(matrix.target, 'wasm32-wasi') }}
         name: Run build
         run: |
           cargo build --target ${{ matrix.target }} --features wasm
@@ -53,6 +56,7 @@ jobs:
         target:
           - wasm32-unknown-unknown
           - wasm32-wasi
+          - wasm32-wasip1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,16 +66,16 @@ jobs:
         with:
           target: ${{ matrix.target }}
           toolchain: stable
-      - if: "${{ matrix.target == 'wasm32-wasi' }}"
+      - if: ${{ startsWith(matrix.target, 'wasm32-wasi') }}
         name: Setup wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
           github_token: ${{ github.token }}
-      - if: "${{ matrix.target == 'wasm32-wasi' }}"
+      - if: ${{ startsWith(matrix.target, 'wasm32-wasi') }}
         name: Run test
         run: |
           cargo test --target ${{ matrix.target }} --features wasm -- --skip standard_files
-      - if: "${{ matrix.target != 'wasm32-wasi' }}"
+      - if: ${{ !startsWith(matrix.target, 'wasm32-wasi') }}
         name: Run build
         run: |
           cargo build --target ${{ matrix.target }} --features wasm

--- a/liblzma-sys/build.rs
+++ b/liblzma-sys/build.rs
@@ -96,7 +96,7 @@ fn main() {
     // List out the WASM targets that need wasm-shim.
     // Note that Emscripten already provides its own C standard library so
     // wasm32-unknown-emscripten should not be included here.
-    let need_wasm_shim = target == "wasm32-unknown-unknown" || target == "wasm32-wasi";
+    let need_wasm_shim = target == "wasm32-unknown-unknown" || target.starts_with("wasm32-wasi");
     if need_wasm_shim {
         println!("cargo:rerun-if-changed=wasm-shim/stdlib.h");
         build.include("wasm-shim/");


### PR DESCRIPTION
the `wasm32-wasi` target is being renamed to `wasm32-wasip1` and the wasm32-wasi target will be removed in the future. so, support that.