### PR TITLE
Define DNDEBUG according to cfg!(debug_assertions)

### DIFF
--- a/liblzma-sys/build.rs
+++ b/liblzma-sys/build.rs
@@ -61,8 +61,12 @@ fn main() {
     src_files.sort();
 
     let mut build = cc::Build::new();
+
+    if !cfg!(debug_assertions) {
+        build.define("NDEBUG", None);
+    }
+
     build
-        .define("NDEBUG", None)
         .files(src_files)
         // all C preproc defines are in `./config.h`
         .define("HAVE_CONFIG_H", "1")


### PR DESCRIPTION
This means assertions in xz are kept when `debug_assertions` is enabled. [Source](https://doc.rust-lang.org/reference/conditional-compilation.html#debug_assertions)