### PR TITLE
🔧 Fix empty input decoding error

### DIFF
--- a/src/bufread.rs
+++ b/src/bufread.rs
@@ -266,7 +266,11 @@ impl<R: BufRead> Read for XzDecoder<R> {
 
             let status = ret?;
             if read > 0 || eof || buf.is_empty() {
-                if read == 0 && status != Status::StreamEnd {
+                if read == 0
+                    && status != Status::StreamEnd
+                    && status != Status::Ok
+                    && !buf.is_empty()
+                {
                     return Err(io::Error::new(
                         io::ErrorKind::UnexpectedEof,
                         "premature eof",

--- a/src/bufread.rs
+++ b/src/bufread.rs
@@ -266,7 +266,11 @@ impl<R: BufRead> Read for XzDecoder<R> {
 
             let status = ret?;
             if read > 0 || eof || buf.is_empty() {
-                if read == 0 && status != Status::StreamEnd && !buf.is_empty() {
+                if read == 0
+                    && status != Status::StreamEnd
+                    && status != Status::Ok
+                    && !buf.is_empty()
+                {
                     return Err(io::Error::new(
                         io::ErrorKind::UnexpectedEof,
                         "premature eof",

--- a/src/bufread.rs
+++ b/src/bufread.rs
@@ -266,11 +266,7 @@ impl<R: BufRead> Read for XzDecoder<R> {
 
             let status = ret?;
             if read > 0 || eof || buf.is_empty() {
-                if read == 0
-                    && status != Status::StreamEnd
-                    && status != Status::Ok
-                    && !buf.is_empty()
-                {
+                if read == 0 && status != Status::StreamEnd {
                     return Err(io::Error::new(
                         io::ErrorKind::UnexpectedEof,
                         "premature eof",


### PR DESCRIPTION
I have a problem with decoding my `.7z` sample. I get an `"premature eof"` error when trying to decode a piece of data.

The error is caused by checking `status` against `Status::StreamEnd` while it is actually is `Status::Ok`.

My case:

- First read: `input.len()=326`, `buf.len()=906`, `read=906`, `consumed=326`, `eof=false`, `status=Ok`
- Second read: `input.len()=0`, `buf.len()=32`, `read=0`, `consumed=0`, `eof=true`, `status=Ok`

After the second read I get the error. I've added a check whether `status` is not `Status::Ok` when dealing with an empty input (`eof=true`) before returning an error.