### PR TITLE
:bug: wasm32-unknown-unknown: Fix undefined malloc/free/calloc symbols

### DIFF
--- a/liblzma-sys/wasm-shim/stdlib.h
+++ b/liblzma-sys/wasm-shim/stdlib.h
@@ -7,16 +7,26 @@ void *rust_lzma_wasm_shim_malloc(size_t size);
 void *rust_lzma_wasm_shim_calloc(size_t nmemb, size_t size);
 void rust_lzma_wasm_shim_free(void *ptr);
 
-inline void *malloc(size_t size) {
-	return rust_lzma_wasm_shim_malloc(size);
-}
+#define malloc(size) rust_lzma_wasm_shim_malloc(size)
 
-inline void *calloc(size_t nmemb, size_t size) {
-	return rust_lzma_wasm_shim_calloc(nmemb, size);
-}
+#define calloc(nmemb, size) rust_lzma_wasm_shim_calloc(nmemb, size);
 
-inline void free(void *ptr) {
-	rust_lzma_wasm_shim_free(ptr);
-}
+// Hack: Avoid replacing `allocator->free` to `allocator->rust_lzma_wasm_shim_free` in
+// Link: liblzma-sys/xz/src/liblzma/common/common.c:79
+//   lzma_free(void *ptr, const lzma_allocator *allocator)
+//   {
+//      if (allocator != NULL && allocator->free != NULL)
+//          allocator->free(allocator->opaque, ptr); //
+//      else
+//          free(ptr);
+//   }
+#define free(...) _FREE_DISPATCH(__VA_ARGS__, free2, free1)(__VA_ARGS__)
+
+#define _FREE_DISPATCH(_1, _2, NAME, ...) NAME
+
+// for free
+#define free1(ptr) rust_lzma_wasm_shim_free(ptr)
+// for allocator->free
+#define free2(info, ptr) free(info, ptr)
 
 #endif // _STDLIB_H


### PR DESCRIPTION
In some cases the definitions of `malloc`, `free`, and `calloc` are used but don't get linked in, leading to undefined symbols (i.e. reference to the symbol in "env").

I was not able to determine exactly why this is happening, but it seems to be related to `malloc`, `calloc`, and `free` being defined as inline functions.  When building in debug mode there are undefined symbols; when building in release mode there are not, presumably because the functions are inlined.

Switching to macros avoids issues of inlining and fixes this issue.