### PR TITLE
:bookmark: Bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liblzma"
-version = "0.3.6"
+version = "0.4.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Portable-Network-Archive Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -19,7 +19,7 @@ exclude = [".github/"]
 members = ["systest"]
 
 [dependencies]
-liblzma-sys = { path = "liblzma-sys", version = "0.3.13", default-features = false }
+liblzma-sys = { path = "liblzma-sys", version = "0.4.0", default-features = false }
 num_cpus = { version = "1.16.0", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -34,11 +34,16 @@ so you can migrate simply.
 - XZ upgraded to 5.4
 - Multithreading is disabled by default.
   This feature is available by enabling the `parallel` feature
-- Support compile to webassembly
+- Support for compiling to WebAssembly
 
 ## Version 0.3.x breaking changes
 
 - XZ upgraded to 5.6
+
+## Version 0.4.x breaking changes
+
+- XZ upgraded to 5.8
+- Dropped `tokio` support (If you need async I/O, use [`async-compression`](https://github.com/Nullus157/async-compression) crate with `lzma` feature flag)
 
 ## License
 

--- a/liblzma-sys/Cargo.toml
+++ b/liblzma-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liblzma-sys"
-version = "0.3.13"
+version = "0.4.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Portable-Network-Archive Developers"]
 build = "build.rs"
 links = "lzma"

--- a/liblzma-sys/src/lib.rs
+++ b/liblzma-sys/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/liblzma-sys/0.3.13")]
+#![doc(html_root_url = "https://docs.rs/liblzma-sys/0.4.0")]
 #![allow(bad_style)]
 
 #[cfg(feature = "bindgen")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! library is not required at runtime:
 //!
 //! ```toml
-//! liblzma = { version = "0.3", features = ["static"] }
+//! liblzma = { version = "0.4", features = ["static"] }
 //! ```
 //!
 //! # Multithreading
@@ -37,7 +37,7 @@
 //! feature of this crate:
 //!
 //! ```toml
-//! liblzma = { version = "0.3", features = ["parallel"] }
+//! liblzma = { version = "0.4", features = ["parallel"] }
 //! ```
 //!
 //! # Async I/O
@@ -49,7 +49,7 @@
 //! async-compression = { version = "0.4", features = ["lzma"] }
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/liblzma/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/liblzma/0.4.0")]
 #![deny(missing_docs)]
 
 use std::io::{self, prelude::*};

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 build = "build.rs"
 edition = "2021"
+publish = false
 
 [dependencies]
 liblzma-sys = { path = "../liblzma-sys" }


### PR DESCRIPTION
## Version 0.4.x breaking changes

- XZ upgraded to 5.8
- Dropped `tokio` support (If you need async I/O, use [`async-compression`](https://github.com/Nullus157/async-compression) crate with `lzma` feature flag)