### PR TITLE
:bug: Fixed failed to build liblzma-sys compiling target for wasm32-unknown-unknown with wasi-sdk 23 or later

### DIFF
--- a/liblzma-sys/build.rs
+++ b/liblzma-sys/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
-const SKIP_FILENAMES: &[&str] = &["crc32_small", "crc64_small"];
+const SKIP_FILENAMES: &[&str] = &["crc32_small", "crc64_small", "crc_clmul_consts_gen"];
 const MIN_LIBLZMA: &str = "5.8.0";
 
 fn main() {


### PR DESCRIPTION


with following errors:
```
warning: liblzma-sys@0.4.0: In file included from xz/src/liblzma/check/crc_clmul_consts_gen.c:24:
warning: liblzma-sys@0.4.0: /opt/wasi-sdk/lib/clang/18/include/inttypes.h:21:15: fatal error: 'inttypes.h' file not found
warning: liblzma-sys@0.4.0:    21 | #include_next <inttypes.h>
warning: liblzma-sys@0.4.0:       |               ^~~~~~~~~~~~
warning: liblzma-sys@0.4.0: 1 error generated.
warning: liblzma-sys@0.4.0: ToolExecError: command did not execute successfully (status code exit status: 1): LC_ALL="C" "/opt/wasi-sdk/bin/clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fno-exceptions" "--target=wasm32-unknown-unknown" "-I" "xz/src/liblzma/api" "-I" "xz/src/liblzma/lzma" "-I" "xz/src/liblzma/lz" "-I" "xz/src/liblzma/check" "-I" "xz/src/liblzma/simple" "-I" "xz/src/liblzma/delta" "-I" "xz/src/liblzma/common" "-I" "xz/src/liblzma/rangecoder" "-I" "xz/src/common" "-I" "/liblzma-rs/liblzma-sys" "-I" "wasm-shim/" "-Wall" "-Wextra" "-std=c99" "-DNDEBUG" "-DHAVE_CONFIG_H=1" "-o" "/liblzma-rs/target/wasm32-unknown-unknown/release/build/liblzma-sys-9e7c70c57ffe7841/out/9958957cfa71505a-crc_clmul_consts_gen.o" "-c" "xz/src/liblzma/check/crc_clmul_consts_gen.c"
error: failed to run custom build command for `liblzma-sys v0.4.0 (/liblzma-rs/liblzma-sys)`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_RELEASE_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/liblzma-rs/target/release/build/liblzma-sys-9f85ed2c6e4a9163/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=build.rs
  cargo:rerun-if-env-changed=LZMA_API_STATIC
  cargo:rerun-if-env-changed=LIBLZMA_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS_wasm32-unknown-unknown
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS_wasm32_unknown_unknown
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG_ALLOW_CROSS
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS
  cargo:rerun-if-env-changed=PKG_CONFIG_wasm32-unknown-unknown
  cargo:rerun-if-env-changed=PKG_CONFIG_wasm32_unknown_unknown
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_wasm32-unknown-unknown
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_wasm32_unknown_unknown
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  cargo:root=/liblzma-rs/target/wasm32-unknown-unknown/release/build/liblzma-sys-9e7c70c57ffe7841/out
  cargo:include=/liblzma-rs/liblzma-sys/xz/src/liblzma/api
  cargo:rerun-if-changed=wasm-shim/assert.h
  cargo:rerun-if-changed=wasm-shim/stdlib.h
  cargo:rerun-if-changed=wasm-shim/string.h
  OUT_DIR = Some(/liblzma-rs/target/wasm32-unknown-unknown/release/build/liblzma-sys-9e7c70c57ffe7841/out)
  OPT_LEVEL = Some(3)
  TARGET = Some(wasm32-unknown-unknown)
  HOST = Some(aarch64-unknown-linux-gnu)
  cargo:rerun-if-env-changed=CC_wasm32-unknown-unknown
  CC_wasm32-unknown-unknown = None
  cargo:rerun-if-env-changed=CC_wasm32_unknown_unknown
  CC_wasm32_unknown_unknown = None
  cargo:rerun-if-env-changed=TARGET_CC
  TARGET_CC = None
  cargo:rerun-if-env-changed=CC
  CC = Some(/opt/wasi-sdk/bin/clang)
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(false)
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS_wasm32_unknown_unknown
  CFLAGS_wasm32_unknown_unknown = None
  cargo:rerun-if-env-changed=CFLAGS_wasm32-unknown-unknown
  CFLAGS_wasm32-unknown-unknown = None
  CARGO_ENCODED_RUSTFLAGS = Some(-Dwarnings)
  cargo:warning=In file included from xz/src/liblzma/check/crc_clmul_consts_gen.c:24:
  cargo:warning=/opt/wasi-sdk/lib/clang/18/include/inttypes.h:21:15: fatal error: 'inttypes.h' file not found
  cargo:warning=   21 | #include_next <inttypes.h>
  cargo:warning=      |               ^~~~~~~~~~~~
  cargo:warning=1 error generated.
  exit status: 0
  exit status: 0
  exit status: 0
  exit status: 0
  exit status: 0
  exit status: 1
  cargo:warning=ToolExecError: command did not execute successfully (status code exit status: 1): LC_ALL="C" "/opt/wasi-sdk/bin/clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fno-exceptions" "--target=wasm32-unknown-unknown" "-I" "xz/src/liblzma/api" "-I" "xz/src/liblzma/lzma" "-I" "xz/src/liblzma/lz" "-I" "xz/src/liblzma/check" "-I" "xz/src/liblzma/simple" "-I" "xz/src/liblzma/delta" "-I" "xz/src/liblzma/common" "-I" "xz/src/liblzma/rangecoder" "-I" "xz/src/common" "-I" "/liblzma-rs/liblzma-sys" "-I" "wasm-shim/" "-Wall" "-Wextra" "-std=c99" "-DNDEBUG" "-DHAVE_CONFIG_H=1" "-o" "/liblzma-rs/target/wasm32-unknown-unknown/release/build/liblzma-sys-9e7c70c57ffe7841/out/9958957cfa71505a-crc_clmul_consts_gen.o" "-c" "xz/src/liblzma/check/crc_clmul_consts_gen.c"
```

This was caused by while compiling unnecessary file `xz/src/liblzma/check/crc_clmul_consts_gen.c`, so excluded it.