### PR TITLE
Fix linking on msvc with static feature with mingw liblzma library

### DIFF
--- a/liblzma-sys/build.rs
+++ b/liblzma-sys/build.rs
@@ -24,9 +24,12 @@ fn main() {
     if !cfg!(feature = "uncheck_liblzma_version") {
         config.atleast_version(MIN_LIBLZMA);
     }
-    let pkg = config.probe("liblzma");
-    if !want_static && !msvc && pkg.is_ok() {
-        return;
+    if !want_static && !msvc {
+        let pkg = config.probe("liblzma");
+
+        if pkg.is_ok() {
+            return;
+        }
     }
 
     let want_parallel = cfg!(feature = "parallel");


### PR DESCRIPTION
Currently, the `liblzma-sys` library attempts to avoid `pkg-config` on msvc to avoid picking up MinGW libaries by accident. However, it fails to do this as the act of calling `pkg_config::Config::probe` will cause cargo metadata to be emitted, causing cargo to try to link to the MinGW libraries anyway.

This can be prevented by only probing when it is known that the user doesn't want a static build and the user isn't on msvc.