### PR TITLE
Improve the documentation of the stream module

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -118,7 +118,8 @@ impl<R: Read> XzDecoder<R> {
     /// Create a new decompression stream, which will read compressed
     /// data from the given input stream, and decompress one xz stream.
     /// It may also consume input data that follows the xz stream.
-    /// Use [`xz::bufread::XzDecoder`] instead to process a mix of xz and non-xz data.
+    /// Use [`bufread::XzDecoder`] instead to
+    /// process a mix of xz and non-xz data.
     #[inline]
     pub fn new(r: R) -> XzDecoder<R> {
         XzDecoder {
@@ -129,7 +130,7 @@ impl<R: Read> XzDecoder<R> {
     /// Create a new parallel decompression stream, which will read compressed
     /// data from the given input stream, and decompress one xz stream.
     /// It may also consume input data that follows the xz stream.
-    /// Use [`xz::bufread::XzDecoder`] instead to process a mix of xz and non-xz data.
+    /// Use [`bufread::XzDecoder`] instead to process a mix of xz and non-xz data.
     #[cfg(feature = "parallel")]
     #[inline]
     pub fn new_parallel(r: R) -> XzDecoder<R> {


### PR DESCRIPTION
I've added a lot of links everywhere, put documentation in the right place (see `Action`), split `Stream` into three blocks so it's easier to find the relevant functions, and various small fixes.