### PR TITLE
:white_check_mark: Update doc example to use no_run attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! # Examples
 //!
-//! ```
+//! ```no_run
 //! use liblzma::read::{XzDecoder, XzEncoder};
 //! use std::io::prelude::*;
 //!


### PR DESCRIPTION
Changed the code block in the documentation to use the `no_run` attribute, preventing the example from being executed during documentation tests.