### PR TITLE
:construction_worker: Add GITHUB_TOKEN env for wasm-bindgen-cli install

### DIFF
--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -48,6 +48,8 @@ jobs:
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall -y --force wasm-bindgen-cli
           cargo test --target ${{ matrix.target }} --features wasm --release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For ease GitHub API rate limits
       - name: Run test
         if: ${{ startsWith(matrix.target, 'wasm32-unknown-emscripten') }}
         run: |


### PR DESCRIPTION
Sets the GITHUB_TOKEN environment variable during wasm-bindgen-cli installation to help avoid GitHub API rate limits.