### PR TITLE
Fix type in lzma_mt_block_size function declaration

### DIFF
--- a/liblzma-sys/src/manual.rs
+++ b/liblzma-sys/src/manual.rs
@@ -249,7 +249,7 @@ extern "C" {
     #[cfg(feature = "parallel")]
     pub fn lzma_stream_decoder_mt(strm: *mut lzma_stream, options: *const lzma_mt) -> lzma_ret;
     #[cfg(feature = "parallel")]
-    pub fn lzma_mt_block_size(filters: *const crate::lzma_filter) -> u64;
+    pub fn lzma_mt_block_size(filters: *const lzma_filter) -> u64;
 
     pub fn lzma_alone_encoder(
         strm: *mut lzma_stream,


### PR DESCRIPTION
Corrects the type of the filters parameter in the lzma_mt_block_size function from crate::lzma_filter to lzma_filter for consistency and correctness.