### PR TITLE
:construction_worker: Add Swatinem/rust-cache to CI test job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,9 @@ jobs:
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: "false"
     - name: Set crt-static
       if: matrix.crt_static == 'yes'
       run: echo RUSTFLAGS=-Ctarget-feature=+crt-static >> $GITHUB_ENV


### PR DESCRIPTION
Cache ~/.cargo registry and index to speed up dependency resolution. Target directory is excluded from cache via cache-targets: false.