### PR TITLE
:bug: Fix AutoFinishXzEncoder::total_in returning total_out

### DIFF
--- a/src/write/auto_finish.rs
+++ b/src/write/auto_finish.rs
@@ -69,7 +69,7 @@ impl<W: Write> AutoFinishXzEncoder<W> {
     /// (e.g. the number of bytes written to this stream.)
     #[inline]
     pub fn total_in(&self) -> u64 {
-        self.0.total_out()
+        self.0.total_in()
     }
 }
 


### PR DESCRIPTION
AutoFinishXzEncoder::total_in delegated to self.0.total_out() due to a copy-paste error, so it reported bytes produced instead of bytes consumed. AutoFinishXzDecoder::total_in already delegated correctly.