### PR TITLE
:bug: Fix IGNORE_CHECK to map to LZMA_IGNORE_CHECK

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -252,7 +252,7 @@ pub const TELL_UNSUPPORTED_CHECK: u32 = liblzma_sys::LZMA_TELL_UNSUPPORTED_CHECK
 
 /// A flag passed when initializing a decoder, causes the decoder to ignore any
 /// integrity checks listed.
-pub const IGNORE_CHECK: u32 = liblzma_sys::LZMA_TELL_UNSUPPORTED_CHECK;
+pub const IGNORE_CHECK: u32 = liblzma_sys::LZMA_IGNORE_CHECK;
 
 /// A flag passed when initializing a decoder, indicates that the stream may be
 /// multiple concatenated xz files.


### PR DESCRIPTION
IGNORE_CHECK was defined as liblzma_sys::LZMA_TELL_UNSUPPORTED_CHECK (0x02) instead of LZMA_IGNORE_CHECK (0x10), so passing it to a decoder enabled the unsupported-check notification flag rather than ignoring integrity checks.