### PR TITLE
:wrench: Group rand and getrandom Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      random:
+        patterns:
+          - "rand"
+          - "getrandom"
   - package-ecosystem: "cargo"
     directory: "liblzma-sys"
     schedule:


### PR DESCRIPTION
Add a Dependabot group so cargo updates for rand and getrandom in the root manifest arrive in a single combined PR instead of separately.